### PR TITLE
Double the ref handle limit

### DIFF
--- a/skyrim64_test/src/patches/CKSSE/BSHandleRefObject_CK.h
+++ b/skyrim64_test/src/patches/CKSSE/BSHandleRefObject_CK.h
@@ -6,13 +6,13 @@ class BSHandleRefObject : public NiRefObject
 {
 private:
 	//
-	// 31             11       10          0
-	// |--------------|--------|-----------|
-	// | Handle Index | Active | Ref Count |
-	// |--------------|--------|-----------|
+	// 31             10       9          0
+	// |--------------|---------|----------|
+	// | Handle Index | Active  |Ref Count |
+	// |--------------|---------|----------|
 	//
-	constexpr static uint32_t ACTIVE_BIT_INDEX = 10;
-	constexpr static uint32_t HANDLE_BIT_INDEX = 11;
+	constexpr static uint32_t ACTIVE_BIT_INDEX = 9;
+	constexpr static uint32_t HANDLE_BIT_INDEX = 10;
 	constexpr static uint32_t REF_COUNT_MASK = (1u << 10) - 1u;
 
 public:

--- a/skyrim64_test/src/patches/CKSSE/BSPointerHandleManager.h
+++ b/skyrim64_test/src/patches/CKSSE/BSPointerHandleManager.h
@@ -4,25 +4,25 @@
 #include "../TES/BSReadWriteLock.h"
 #include "TESForm_CK.h"
 
-template<int IndexBits = 21, int AgeCountBits = 6>
+template<int IndexBits = 25, int AgeCountBits = 6>
 class BSUntypedPointerHandle
 {
 public:
 	//
-	// NOTE: Handle index bits increased from 20 (vanilla) to 21 (limit doubled)
+	// NOTE: Handle index bits increased from 20 (vanilla) to 25
 	//
-	// 31       28       27    21             0
-	// |--------|--------|-----|--------------|
-	// | Unused | Active | Age | Handle Index |
-	// |--------|--------|-----|--------------|
+	// 31       30       24                   0
+	// |--------|--------|--------------------|
+	// | Active |   Age  |    Handle Index    |
+	// |--------|--------|--------------------|
 	//
 	constexpr static uint32_t INDEX_BITS		= IndexBits;
 	constexpr static uint32_t AGE_BITS			= AgeCountBits;
 	constexpr static uint32_t UNUSED_BIT_START	= INDEX_BITS + AGE_BITS;				// 26 in vanilla
 
-	constexpr static uint32_t INDEX_MASK		= (1u << INDEX_BITS) - 1u;				// 0x00FFFFF
-	constexpr static uint32_t AGE_MASK			= ((1u << AGE_BITS) - 1u) << INDEX_BITS;// 0x3F00000
-	constexpr static uint32_t ACTIVE_BIT_MASK	= 1u << UNUSED_BIT_START;				// 0x4000000
+	constexpr static uint32_t INDEX_MASK		= (1u << INDEX_BITS) - 1u;				// 0x01FFFFFF
+	constexpr static uint32_t AGE_MASK			= ((1u << AGE_BITS) - 1u) << INDEX_BITS;// 0x7E000000
+	constexpr static uint32_t ACTIVE_BIT_MASK	= 1u << UNUSED_BIT_START;				// 0x80000000
 
 	constexpr static uint32_t MAX_HANDLE_COUNT	= 1u << INDEX_BITS;
 


### PR DESCRIPTION
I tried to double the ref handle limit again, although I'm not entirely sure this would be the right way to do it.
I stole one bit from the ref count, where I can only hope that this doesn't cause any major issues. I tested this in the Creation Kit and it seemed to load a couple of very big mods that couldn't have been loaded without this tweak. I hope this is a valid solution. Otherwise I guess the addresses have to be moved up to 64-bit integers.